### PR TITLE
修复一键部署bug

### DIFF
--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -1,4 +1,4 @@
 %1 mshta vbscript:CreateObject("Shell.Application").ShellExecute("cmd.exe","/c %~s0 ::","","runas",1)(window.close)&&exit
 cd/d "%~dp0"
-pip install -r requirements.txt
+pip install -r requirements.txt -i https://pypi.doubanio.com/simple/
 pause

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyinstaller
 pyuac
 pillow
 keyboard
+requests


### PR DESCRIPTION
1、更换python原始源，解决联通 移动连接不上的问题
2、run使用了requests库，但是一键部署的名单里没有requests库，增加requests库