### PR TITLE
GUI设置中的4个勾选框可保存到info.txt中

### DIFF
--- a/gui/config.py
+++ b/gui/config.py
@@ -17,20 +17,16 @@ def config_view(page: Page):
         page.update()
 
     def show_map_checkbox_changed(_e):
-        page.show_map_mode = not page.show_map_mode
-        config.show_map_mode = page.show_map_mode
+        config.show_map_mode = (config.show_map_mode + 1) % 2
 
     def debug_checkbox_changed(_e):
-        page.debug_mode = (page.debug_mode + 1) % 3
-        config.debug_mode = page.debug_mode
+        config.debug_mode = (config.debug_mode + 1) % 3
 
     def speed_checkbox_changed(_e):
-        page.speed_mode = (page.speed_mode + 1) % 3
-        config.speed_mode = page.speed_mode
+        config.speed_mode = (config.speed_mode + 1) % 3
 
     def force_update_checkbox_changed(_e):
-        page.force_update = not page.force_update
-        config.force_update = page.force_update
+        config.force_update = (config.force_update + 1) % 2
 
     def difficult_changed(e: ControlEvent):
         config.difficult = e.data
@@ -41,7 +37,7 @@ def config_view(page: Page):
     def textbox_changed(e):
         config.order_text = e.control.value
 
-    def get_debug_mode(d):
+    def get_info_mode(d):
         ls = [False, True, None]
         return ls[d]
 
@@ -92,24 +88,24 @@ def config_view(page: Page):
                                     [
                                         ft.Checkbox(
                                             label="显示地图",
-                                            value=config.show_map_mode,
+                                            value=get_info_mode(config.show_map_mode),
                                             on_change=show_map_checkbox_changed,
                                         ),
                                         ft.Checkbox(
                                             label="调试模式",
-                                            value=get_debug_mode(config.debug_mode),
+                                            value=get_info_mode(config.debug_mode),
                                             tristate=True,
                                             on_change=debug_checkbox_changed,
                                         ),
                                         ft.Checkbox(
                                             label="速通模式",
                                             tristate=True,
-                                            value=get_debug_mode(config.speed_mode),
+                                            value=get_info_mode(config.speed_mode),
                                             on_change=speed_checkbox_changed,
                                         ),
                                         ft.Checkbox(
                                             label="强制更新",
-                                            value=config.force_update,
+                                            value=get_info_mode(config.force_update),
                                             on_change=force_update_checkbox_changed,
                                         ),
                                     ]

--- a/utils/config.py
+++ b/utils/config.py
@@ -47,7 +47,7 @@ class Config:
     def save(self):
         with open(self.text, "w", encoding="utf-8") as f:
             f.write(
-                f"{self.order_text}\n{self.angle}\n{self.diffi}\n{self.fate}\n{self.map_sha}"
+                f"{self.order_text}\n{self.angle}\n{self.diffi}\n{self.fate}\n{self.map_sha}\n{self.show_map_mode}\n{self.debug_mode}\n{self.speed_mode}\n{self.force_update}"
             )
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -39,6 +39,10 @@ class Config:
                     self.difficult = str(int(f.readline().strip()))
                     self.fate = f.readline().strip()
                     self.map_sha = f.readline().strip()
+                    self.show_map_mode = int(f.readline().strip())
+                    self.debug_mode = int(f.readline().strip())
+                    self.speed_mode = int(f.readline().strip())
+                    self.force_update = int(f.readline().strip())
                 except:
                     pass
         else:


### PR DESCRIPTION
发现GUI的额外选项不会保存设置，由于我想每次打开直接用速刷模式、识别失败不结算，所以简单改了一下两个config.py……