### PR TITLE
refactor(states.py): press v to auto battle

### DIFF
--- a/states.py
+++ b/states.py
@@ -142,7 +142,7 @@ class SimulatedUniverse(UniverseUtils):
         if self.check("auto_2", 0.3755,0.0333):
             # 需要打开自动战斗
             if self.check("c", 0.9464,0.1287, threshold=0.985):
-                self.click((0.0891, 0.9676))
+                self.press('v')
             # self.battle：最后一次处于战斗状态的时间，0表示处于非战斗状态
             self.battle = time.time()
             return 1


### PR DESCRIPTION
在战斗状态时通过键盘按键 `v` 可以更改自动战斗设置，而无需使用鼠标定位点击。

通过按键替代坐标点击也更具鲁棒性。