### PR TITLE
utf-8显示编码提示错误bug修复

### DIFF
--- a/states.py
+++ b/states.py
@@ -538,7 +538,7 @@ class SimulatedUniverse(UniverseUtils):
             new_cnt = 0
             if os.path.exists(file_name):
                 time_cnt = os.path.getmtime(file_name)
-                with open(file_name,'r', encoding="utf-8") as fh:
+                with open(file_name,'r', encoding="utf-8", errors='ignore') as fh:
                     s=fh.readlines()
                     try:
                         new_cnt = int(s[0].strip('\n'))
@@ -547,7 +547,7 @@ class SimulatedUniverse(UniverseUtils):
                         pass
             else:
                 os.makedirs('logs',exist_ok=1)
-                with open(file_name, 'w', encoding="utf-8") as file:
+                with open(file_name, 'w', encoding="utf-8", errors='ignore') as file:
                     file.write("0")
                     file.close()
                 time_cnt = os.path.getmtime(file_name)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -25,7 +25,7 @@ def notif(title,msg,cnt=None):
     else:
         tm=None
     if os.path.exists('logs/notif.txt'):
-        with open('logs/notif.txt','r', encoding="utf-8") as fh:
+        with open('logs/notif.txt','r', encoding="utf-8", errors='ignore') as fh:
             s=fh.readlines()
             try:
                 cnt=s[0].strip('\n')


### PR DESCRIPTION
原报错代码为：
File "d:\Download\模拟宇宙\states.py", line 542, in update_count
    s=fh.readlines()
和
File "d:\Download\模拟宇宙\utils\utils.py", line 29, in notif
    s=fh.readlines()
这两个文件出现以下报错
File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd2 in position 3: invalid continuation byte
经gpt修改为
with open(file_path, 'r', encoding='utf-8', errors='ignore') as fh:
    s = fh.readlines()
后不再出现此bug报错
此类为罕见编码报错，此修改后忽略该错误可继续正常运行
