### PR TITLE
修复环境依赖问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow
 keyboard
 requests
 ppocr-onnx
+pyscreeze==0.1.28


### PR DESCRIPTION
PyAutoGUI无法引入特定版本下的pyscreeze包导致报错.
```PyAutoGUIException: PyAutoGUI was unable to import pyscreeze.```
解决方案：
在requirements文件中加入```pyscreeze==0.1.28```固定版本