### PR TITLE
适配1.2版本截图坐标位置

### DIFF
--- a/states.py
+++ b/states.py
@@ -205,6 +205,9 @@ class SimulatedUniverse(UniverseUtils):
                 for _ in range(4):
                     img = self.check('z',0.3182,0.4333,mask="mask_f",large=False)
                     text = self.ts.sim_list(self.tk.interacts,img)
+                    if not text:
+                        img = self.check('z',0.3302,0.4503,mask="mask_f",large=False)
+                        text = self.ts.sim_list(self.tk.interacts,img)
                     if text is not None:
                         break
                     time.sleep(0.3)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -502,6 +502,10 @@ class UniverseUtils:
             return False
         img = self.check('z',0.3182,0.4333,mask="mask_f",large=False)
         text = self.ts.sim_list(self.tk.interacts,img)
+        if text is None:
+            # 使用新坐标重新尝试
+            img = self.check('z',0.3302,0.4503,mask="mask_f",large=False)
+            text = self.ts.sim_list(self.tk.interacts,img)
         is_killed = text in ['沉浸','紧锁','复活','下载']
         return text is not None and not is_killed
 
@@ -628,7 +632,8 @@ class UniverseUtils:
             nt = time.time()
             while time.time()-nt<1:
                 self.get_screen()
-                if self.ts.sim("沉浸",self.check('z',0.3182,0.4333,mask="mask_f",large=False)):
+                if self.ts.sim("沉浸",self.check('z',0.3182,0.4333,mask="mask_f",large=False)) or \
+                    self.ts.sim("沉浸",self.check('z',0.3302,0.4503,mask="mask_f",large=False)):
                     self.press('f')
                     pyautogui.keyUp('w')
                     break


### PR DESCRIPTION
修正1.2版本中按钮位置变化导致OCR截图位置错误，无法处理事件层的问题 #113 