### PR TITLE
增加计数重置时间为服务器时间的选项

### DIFF
--- a/gui/config.py
+++ b/gui/config.py
@@ -34,6 +34,9 @@ def config_view(page: Page):
     def fate_changed(e: ControlEvent):
         config.fate = e.data
 
+    def timezone_changed(e: ControlEvent):
+        config.timezone = e.data
+
     def textbox_changed(e):
         config.order_text = e.control.value
 
@@ -141,6 +144,19 @@ def config_view(page: Page):
                                             ],
                                             value=config.fate,
                                             on_change=fate_changed,
+                                        ),
+                                        ft.Dropdown(
+                                            width=150,
+                                            label="时区",
+                                            hint_text="影响计数刷新时间",
+                                            options=[
+                                                ft.dropdown.Option("Default"),
+                                                ft.dropdown.Option("Asia"),
+                                                ft.dropdown.Option("America"),
+                                                ft.dropdown.Option("Europe"),
+                                            ],
+                                            value=config.timezone,
+                                            on_change=timezone_changed,
                                         ),
                                     ]
                                 ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ keyboard
 requests
 ppocr-onnx
 pyscreeze==0.1.28
+tzdata

--- a/states.py
+++ b/states.py
@@ -17,6 +17,7 @@ import os
 from align_angle import main as align_angle
 from utils.config import config
 import datetime
+from zoneinfo import ZoneInfo
 
 pyautogui.FAILSAFE=False
 
@@ -517,10 +518,24 @@ class SimulatedUniverse(UniverseUtils):
         else:
             new_cnt = self.count + 1
             time_cnt = self.count_tm
-        dt = datetime.datetime.fromtimestamp(time.time())
+        dt = datetime.datetime.now().astimezone()
+        '''
+        America: GMT-5
+        Asia: GMT+8
+        Europe: GMT+1
+        TW, HK, MO: GMT+8
+        '''
+        tz_dict = {
+            'Default': None,
+            'America': ZoneInfo('US/Central'),
+            'Asia':ZoneInfo('Asia/Shanghai'),
+            'Europe':ZoneInfo('Europe/London'),
+        }
+        # convert to server time
+        dt.astimezone(tz_dict[config.timezone])
         current_weekday = dt.weekday()
         monday = dt + datetime.timedelta(days=-current_weekday)
-        target_datetime = datetime.datetime(monday.year, monday.month, monday.day, 4, 0, 0)
+        target_datetime = datetime.datetime(monday.year, monday.month, monday.day, 4, 0, 0,tzinfo=tz_dict[config.timezone])
         monday_ts = target_datetime.timestamp()
         if dt.timestamp()>=monday_ts and time_cnt<monday_ts:
             self.count=int(not read)

--- a/states.py
+++ b/states.py
@@ -525,17 +525,23 @@ class SimulatedUniverse(UniverseUtils):
         Europe: GMT+1
         TW, HK, MO: GMT+8
         '''
-        tz_dict = {
-            'Default': None,
-            'America': ZoneInfo('US/Central'),
-            'Asia':ZoneInfo('Asia/Shanghai'),
-            'Europe':ZoneInfo('Europe/London'),
-        }
+        tz_info = None
+        try:
+            tz_dict = {
+                'Default': None,
+                'America': ZoneInfo('US/Central'),
+                'Asia':ZoneInfo('Asia/Shanghai'),
+                'Europe':ZoneInfo('Europe/London'),
+            }
+            tz_info = tz_dict[config.timezone]
+        except:
+            pass
+
         # convert to server time
-        dt.astimezone(tz_dict[config.timezone])
+        dt.astimezone(tz_info)
         current_weekday = dt.weekday()
         monday = dt + datetime.timedelta(days=-current_weekday)
-        target_datetime = datetime.datetime(monday.year, monday.month, monday.day, 4, 0, 0,tzinfo=tz_dict[config.timezone])
+        target_datetime = datetime.datetime(monday.year, monday.month, monday.day, 4, 0, 0,tzinfo=tz_info)
         monday_ts = target_datetime.timestamp()
         if dt.timestamp()>=monday_ts and time_cnt<monday_ts:
             self.count=int(not read)

--- a/utils/config.py
+++ b/utils/config.py
@@ -17,6 +17,8 @@ class Config:
         self.speed_mode = 0
         self.force_update = 0
         self.unlock = 0
+        self.timezones = ['America', 'Asia','Europe','Default']
+        self.timezone = 'Default'
         self.read()
 
     @property
@@ -44,6 +46,7 @@ class Config:
                     self.debug_mode = int(f.readline().strip())
                     self.speed_mode = int(f.readline().strip())
                     self.force_update = int(f.readline().strip())
+                    self.timezone = f.readline().strip()
                 except:
                     pass
         else:
@@ -52,7 +55,7 @@ class Config:
     def save(self):
         with open(self.text, "w", encoding="utf-8") as f:
             f.write(
-                f"{self.order_text}\n{self.angle}\n{self.diffi}\n{self.fate}\n{self.map_sha}\n{self.show_map_mode}\n{self.debug_mode}\n{self.speed_mode}\n{self.force_update}"
+                f"{self.order_text}\n{self.angle}\n{self.diffi}\n{self.fate}\n{self.map_sha}\n{self.show_map_mode}\n{self.debug_mode}\n{self.speed_mode}\n{self.force_update}\n{self.timezone}"
             )
 
 


### PR DESCRIPTION
原计数重置时间取决于电脑本地时间而非服务器时间。加了个服务器时间配置，默认为default，按原有逻辑结算。
引入一个新依赖tzdata，因为Windows没有系统时区数据库，没有也不会报错。