### PR TITLE
[模拟宇宙]增加一个选项，打开后会在BOSS和精英战前使用消耗品

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ bonus in [0,1]：是否开启沉浸奖励
 
 speed in [0,1]：开启速通模式
 
+consumable in [0,1]：精英和首领战之前是否使用最左上角的消耗品
+
 debug in [0,1,2]：开启调试模式
 
 find in [0,1]：0为录图，1为跑图
@@ -74,6 +76,7 @@ config:
   show_map_mode: 0
   debug_mode: 0
   speed_mode: 0
+  use_consumable: 0
   slow_mode: 0
   force_update: 0
   timezone: Default

--- a/README_CHT.md
+++ b/README_CHT.md
@@ -51,6 +51,8 @@ bonus in [0,1]：是否開啟沈浸獎勵
 
 speed in [0,1]：開啟速通模式
 
+consumable in [0,1]：菁英和首領戰之前是否使用最左上角的消耗品
+
 debug in [0,1,2]：開啟調試模式
 
 find in [0,1]：0為錄圖，1為跑圖
@@ -68,6 +70,7 @@ config:
   show_map_mode: 0
   debug_mode: 0
   speed_mode: 0
+  use_consumable: 0
   slow_mode: 0
   force_update: 0
   timezone: Default

--- a/README_ENG.md
+++ b/README_ENG.md
@@ -49,6 +49,8 @@ bonus in [0,1]: Whether to enable immersion bonus.
 
 speed in [0,1]: Enable speedrun mode.
 
+consumable in [0,1]：Enable using the most top-left consumable before elite & boss battle
+
 debug in [0,1,2]: Enable debug mode.
 
 find in [0,1]: 0 for recording, 1 for speedrunning.
@@ -64,6 +66,7 @@ config:
   show_map_mode: 0
   debug_mode: 0
   speed_mode: 0
+  use_consumable: 0
   slow_mode: 0
   force_update: 0
   timezone: Default

--- a/gui/choose.py
+++ b/gui/choose.py
@@ -68,6 +68,7 @@ def choose_view(page: Page):
             int(config.debug_mode),
             int(config.show_map_mode),
             int(config.speed_mode),
+            int(config.use_consumable),
             int(config.slow_mode),
             unlock = True,
             bonus=config.bonus,

--- a/info_example.yml
+++ b/info_example.yml
@@ -25,6 +25,7 @@ config:
   show_map_mode: 0
   debug_mode: 0
   speed_mode: 0
+  use_consumable: 0
   slow_mode: 0
   force_update: 0
   timezone: Default

--- a/states.py
+++ b/states.py
@@ -28,7 +28,7 @@ version = "v6.04 Pro Max"
 
 class SimulatedUniverse(UniverseUtils):
     def __init__(
-        self, find, debug, show_map, speed, slow, nums=10000, unlock=False, bonus=False, update=0, gui=0
+        self, find, debug, show_map, speed, consumable, slow, nums=10000, unlock=False, bonus=False, update=0, gui=0
     ):
         super().__init__()
         # t1 = threading.Thread(target=os.system,kwargs={'command':'notif.exe > NUL 2>&1'})
@@ -78,6 +78,7 @@ class SimulatedUniverse(UniverseUtils):
         self.find = find
         self.debug = debug
         self.speed = speed
+        self.consumable = consumable
         self.slow = slow
         self._show_map = show_map & find
         self.floor = 0
@@ -464,6 +465,8 @@ class SimulatedUniverse(UniverseUtils):
                         log.info("target %s" % self.target)
                     if self._stop:
                         return 1
+                    if self.consumable != 0 and self.floor in [3, 7, 12]:
+                        self.use_consumable(1, 1)
                     self.press("1")
                 # 录制模式，保存初始小地图
                 else:
@@ -961,8 +964,8 @@ class SimulatedUniverse(UniverseUtils):
 
 
 def main():
-    log.info(f"find: {find}, debug: {debug}, show_map: {show_map}")
-    su = SimulatedUniverse(find, debug, show_map, speed, slow, nums=nums, bonus=bonus, update=update)
+    log.info(f"find: {find}, debug: {debug}, show_map: {show_map}, consumable: {consumable}")
+    su = SimulatedUniverse(find, debug, show_map, speed, consumable, slow, nums=nums, bonus=bonus, update=update)
     try:
         su.start()
     except ValueError as e:
@@ -982,6 +985,7 @@ if __name__ == "__main__":
         show_map = 0
         update = 0
         speed = 0
+        consumable = 0
         slow = 0
         bonus = 0
         nums = 10000

--- a/utils/config.py
+++ b/utils/config.py
@@ -20,6 +20,7 @@ class Config:
         self.show_map_mode = 0
         self.debug_mode = 0
         self.speed_mode = 0
+        self.use_consumable = 0
         self.slow_mode = 0
         self.force_update = 0
         self.unlock = 0
@@ -62,6 +63,7 @@ class Config:
                     self.show_map_mode = config['show_map_mode']
                     self.debug_mode = config['debug_mode']
                     self.speed_mode = config['speed_mode']
+                    self.use_consumable = config['use_consumable']
                     self.force_update = config['force_update']
                     self.timezone = config['timezone']
                     self.slow_mode = config['slow_mode']
@@ -131,6 +133,7 @@ class Config:
                     "show_map_mode": self.show_map_mode,
                     "debug_mode": self.debug_mode,
                     "speed_mode": self.speed_mode,
+                    "use_consumable": self.use_consumable,
                     "slow_mode": self.slow_mode,
                     "force_update": self.force_update,
                     "timezone": self.timezone

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -183,6 +183,23 @@ class UniverseUtils:
         time.sleep(t)
         keyops.keyUp(c)
 
+    # 使用x排，y列的消耗品
+    def use_consumable(self, x, y):
+        self.press("b", 0.5)
+        time.sleep(1)
+        self.click((0.903 - 0.06 * (x - 1), 0.827 - 0.14 * (y - 1)))
+        time.sleep(0.5)
+        # 点击使用
+        self.click((0.154,0.088))
+        time.sleep(0.5)
+        # 点击确认
+        self.click((0.386,0.294))
+        time.sleep(0.5)
+        # 覆盖效果
+        self.click((0.386,0.294))
+        time.sleep(3)
+        self.press("b", 0.5)
+
     def get_point(self, x, y):
         # 得到一个点的浮点表示
         x = self.x1 - x


### PR DESCRIPTION
增加一个选项，打开后会在BOSS和精英战前使用最左上角的消耗品，这样一来可以提高刷图效率，减少翻车率。

实测我的低配虚无世界三可以减少2分钟/每轮

可以使用收藏键来调整消耗品的位置

![image](https://github.com/CHNZYX/Auto_Simulated_Universe/assets/2311828/1961b014-ee2d-444b-9df9-abb32cda1fab)
