### PR TITLE
修复黑塔强化后无限f

### DIFF
--- a/simul.py
+++ b/simul.py
@@ -692,6 +692,7 @@ class SimulatedUniverse(UniverseUtils):
                     time.sleep(0.3)
                     self.get_screen()
             self.press("esc")
+            self.press("w", 2)
             tm = time.time()
             while time.time()-tm<2 and not self.check("f", 0.4443, 0.4417, mask="mask_f1", threshold=0.96) and not self.isrun():
                 self.get_screen()


### PR DESCRIPTION
有一定几率会卡在强化的黑塔无限f 前进2秒躲开黑塔避免卡主