### PR TITLE
Fix: Initialize total_events to avoid unbound variable error

### DIFF
--- a/diver.py
+++ b/diver.py
@@ -719,6 +719,7 @@ class DivergentUniverse(UniverseUtils):
                 tm = time.time()
                 self.get_screen()
                 self.get_text_position()
+                total_events = []  # 初始化 total_events
                 while time.time() - tm < 5:
                     self.get_screen()
                     if self.get_text_position():


### PR DESCRIPTION
This PR fixes the issue where total_events is not initialized in certain cases, causing a cannot access local variable 'total_events' where it is not associated with a value error.
Changes:
Initialize total_events as an empty list.
Assign a default value if total_events is empty.