### PR TITLE
调整对齐事件操作间隔

### DIFF
--- a/diver.py
+++ b/diver.py
@@ -694,6 +694,7 @@ class DivergentUniverse(UniverseUtils):
         if event_text:
             if abs(950-event_text) >= 50:
                 self.press(key,0.2)
+                time.sleep(0.5)
             event_text_after = self.find_event_text()
             if event_text_after:
                 sub = event_text - event_text_after
@@ -718,11 +719,11 @@ class DivergentUniverse(UniverseUtils):
 
             for _ in range(sub):
                 self.press('d',0.2)
-                time.sleep(0.1)
+                time.sleep(0.5)
 
             for _ in range(-sub):
                 self.press('a',0.2)
-                time.sleep(0.1)
+                time.sleep(0.5)
 
             if click:
                 pyautogui.click()


### PR DESCRIPTION
在对齐事件开始，检查横向距离与单步移动距离时，增加检查前间隔，使单步移动距离检查更准确。同时增加后续每步之间间隔，使单步之间距离误差更小