### PR TITLE
修复 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,4 +204,4 @@ F8/‘停止’按钮停止运行。
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CHNZYX/Auto_Simulated_Universe&type=Date)](https://star-history.com/#CHNZYX/Auto_Simulated_Universe&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CHNZYX/Auto_Simulated_Universe&type=Date)](https://star-history.dera.page/#CHNZYX/Auto_Simulated_Universe&Date)


### PR DESCRIPTION
当前的 Star History 图表已经失效, 因为 GitHub stargazer API 存在限制. 本 PR 将其切换到替代数据源, 使图表恢复正常显示.